### PR TITLE
Fix renaming module

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ First, make sure you have an API KEY to use the framework, if you don't have it,
 To start to work with the framework in Javascript, you will have to import it to the `.js` file you will be working, so add the following code:
 
 ```javascript
-import RNBridgefy from 'react-native-bridgefy-sdk';
+import RNBridgefy from 'react-native-bridgefy';
 import {
     ...
     NativeEventEmitter,

--- a/ios/RNBridgefy.podspec
+++ b/ios/RNBridgefy.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   # s.license     = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author        = { "Bridgefy" => "contact@bridgefy.me" }
   s.platform      = :ios, "11.0"
-  s.source        = { :git => "https://bitbucket.org/bridgefy/react-native-bridgefy-sdk", :tag => "master" }
+  s.source        = { :git => "https://github.com/bridgefy/react-native-bridgefy", :tag => "master" }
   s.source_files  = "**/*.{h,m}"
   s.requires_arc = true
 

--- a/samples/BridgefiedChat/App.tsx
+++ b/samples/BridgefiedChat/App.tsx
@@ -12,9 +12,9 @@ import { GiftedChat, IMessage, User } from 'react-native-gifted-chat';
 import 'react-native-get-random-values';
 import { v4 as uuid } from 'uuid';
 
-import RNBridgefy, { BrdgNativeEventEmitter } from 'react-native-bridgefy-sdk';
+import RNBridgefy, { BrdgNativeEventEmitter } from 'react-native-bridgefy';
 
-import { BridgefyMessage, BridgefyClient, MessageFailedEvent, MessageReceivedExceptionEvent, StartErrorEvent, StoppedEvent, DeviceConnectedEvent, DeviceLostEvent, EventOccurredEvent } from 'react-native-bridgefy-sdk';
+import { BridgefyMessage, BridgefyClient, MessageFailedEvent, MessageReceivedExceptionEvent, StartErrorEvent, StoppedEvent, DeviceConnectedEvent, DeviceLostEvent, EventOccurredEvent } from 'react-native-bridgefy';
 
 const BRDG_LICENSE_KEY:string = "COPY YOU LICENSE KEY HERE";
 

--- a/samples/BridgefiedChat/ios/Podfile.lock
+++ b/samples/BridgefiedChat/ios/Podfile.lock
@@ -354,7 +354,7 @@ DEPENDENCIES:
   - React-RCTText (from `../node_modules/react-native/Libraries/Text`)
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - RNBridgefy (from `../node_modules/react-native-bridgefy-sdk/ios`)
+  - RNBridgefy (from `../node_modules/react-native-bridgefy/ios`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -427,7 +427,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   RNBridgefy:
-    :path: "../node_modules/react-native-bridgefy-sdk/ios"
+    :path: "../node_modules/react-native-bridgefy/ios"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 

--- a/samples/BridgefiedChat/package.json
+++ b/samples/BridgefiedChat/package.json
@@ -14,7 +14,7 @@
     "@types/uuid": "^8.3.0",
     "react": "17.0.1",
     "react-native": "0.63.4",
-    "react-native-bridgefy-sdk": "file:../..",
+    "react-native-bridgefy": "file:../..",
     "react-native-get-random-values": "^1.5.1",
     "react-native-gifted-chat": "^0.16.3",
     "uuid": "^8.3.2"

--- a/samples/BridgefiedChat/yarn.lock
+++ b/samples/BridgefiedChat/yarn.lock
@@ -5989,7 +5989,7 @@ react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
-"react-native-bridgefy-sdk@file:../..":
+"react-native-bridgefy@file:../..":
   version "2.0.1"
 
 react-native-communications@^2.2.1:

--- a/samples/NearbyDrop/App.tsx
+++ b/samples/NearbyDrop/App.tsx
@@ -28,11 +28,11 @@ import Icon from 'react-native-vector-icons/Ionicons';
 
 import prompt from 'react-native-prompt-android';
 
-import RNBridgefy, { BrdgNativeEventEmitter } from 'react-native-bridgefy-sdk';
+import RNBridgefy, { BrdgNativeEventEmitter } from 'react-native-bridgefy';
 import { BridgefyMessage, BridgefyClient, MessageFailedEvent, MessageReceivedExceptionEvent, 
     StartErrorEvent, StoppedEvent, DeviceConnectedEvent, DeviceLostEvent, DeviceDetectedEvent,
-    DeviceUnavailableEvent } from 'react-native-bridgefy-sdk';
-import { MessageDataProgressEvent } from '../react-native-bridgefy-sdk/typings';
+    DeviceUnavailableEvent } from 'react-native-bridgefy';
+import { MessageDataProgressEvent } from '../react-native-bridgefy/typings';
 
 interface AppMsg {
     msg: string

--- a/samples/NearbyDrop/ios/Podfile.lock
+++ b/samples/NearbyDrop/ios/Podfile.lock
@@ -358,7 +358,7 @@ DEPENDENCIES:
   - React-RCTText (from `../node_modules/react-native/Libraries/Text`)
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - RNBridgefy (from `../node_modules/react-native-bridgefy-sdk/ios`)
+  - RNBridgefy (from `../node_modules/react-native-bridgefy/ios`)
   - RNFileViewer (from `../node_modules/react-native-file-viewer`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -433,7 +433,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   RNBridgefy:
-    :path: "../node_modules/react-native-bridgefy-sdk/ios"
+    :path: "../node_modules/react-native-bridgefy/ios"
   RNFileViewer:
     :path: "../node_modules/react-native-file-viewer"
   RNVectorIcons:

--- a/samples/NearbyDrop/package.json
+++ b/samples/NearbyDrop/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "17.0.1",
     "react-native": "0.63.4",
-    "react-native-bridgefy-sdk": "file:../..",
+    "react-native-bridgefy": "file:../..",
     "react-native-document-picker": "^4.1.0",
     "react-native-file-viewer": "^2.1.4",
     "react-native-prompt-android": "^1.1.0",

--- a/samples/NearbyDrop/yarn.lock
+++ b/samples/NearbyDrop/yarn.lock
@@ -5668,7 +5668,7 @@ react-is@^16.12.0, react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
   integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
-"react-native-bridgefy-sdk@file:../..":
+"react-native-bridgefy@file:../..":
   version "2.0.1"
 
 react-native-document-picker@^4.1.0:


### PR DESCRIPTION
The module has been renamed to `react-native-bridgefy` when it was previously `react-native-bridgefy-sdk` however many places (samples, README, etc...) still mention the old name.